### PR TITLE
Twitch events overview updates, and some small accessibility refactors

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,34 +1,34 @@
 import 'reflect-metadata';
 import '../polyfills';
 
-import {BrowserModule, DomSanitizer} from '@angular/platform-browser';
-import {NgModule} from '@angular/core';
-import {FormsModule} from '@angular/forms';
-import {HttpClient, HttpClientModule} from '@angular/common/http';
-import {CoreModule} from './core/core.module';
-import {SharedModule} from './shared/shared.module';
+import { BrowserModule, DomSanitizer } from '@angular/platform-browser';
+import { NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { HttpClient, HttpClientModule } from '@angular/common/http';
+import { CoreModule } from './core/core.module';
+import { SharedModule } from './shared/shared.module';
 
-import {AppRoutingModule} from './app-routing.module';
+import { AppRoutingModule } from './app-routing.module';
 // NG Translate
-import {TranslateLoader, TranslateModule} from '@ngx-translate/core';
-import {TranslateHttpLoader} from '@ngx-translate/http-loader';
+import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
+import { TranslateHttpLoader } from '@ngx-translate/http-loader';
 
-import {AppComponent} from './app.component';
-import {BrowserAnimationsModule} from "@angular/platform-browser/animations";
-import {MatIconRegistry} from "@angular/material/icon";
-import {MatButtonModule} from "@angular/material/button";
-import {AkitaNgDevtools} from '@datorama/akita-ngdevtools';
-import {AppConfig} from '../environments/environment';
-import {TargetScreenComponent} from "./target-screen/target-screen.component";
-import {MediaTypeClassPipe} from './target-screen/media-type-class.pipe';
-import {ServicesModule} from "./shared/services/services.module";
-import {DialogsModule} from "./shared/components/dialogs/dialogs.module";
-import {MaterialCssVariables, MaterialCssVarsModule, MaterialCssVarsService} from "angular-material-css-vars";
-import {StyleguideColors} from './shared/styleguide/styleguide.component';
+import { AppComponent } from './app.component';
+import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
+import { MatIconRegistry } from "@angular/material/icon";
+import { MatButtonModule } from "@angular/material/button";
+import { AkitaNgDevtools } from '@datorama/akita-ngdevtools';
+import { AppConfig } from '../environments/environment';
+import { TargetScreenComponent } from "./target-screen/target-screen.component";
+import { MediaTypeClassPipe } from './target-screen/media-type-class.pipe';
+import { ServicesModule } from "./shared/services/services.module";
+import { DialogsModule } from "./shared/components/dialogs/dialogs.module";
+import { MaterialCssVariables, MaterialCssVarsModule, MaterialCssVarsService } from "angular-material-css-vars";
+import { StyleguideColors } from './shared/styleguide/styleguide.component';
 
-import {PipesModule} from "./core/pipes/pipes.module";
-import {MediaToggleDirective} from './target-screen/media-toggle.directive';
-import {APP_ICONS} from "./app.icons";
+import { PipesModule } from "./core/pipes/pipes.module";
+import { MediaToggleDirective } from './target-screen/media-toggle.directive';
+import { APP_ICONS } from "./app.icons";
 
 // AoT requires an exported function for factories
 export function HttpLoaderFactory(http: HttpClient): TranslateHttpLoader {
@@ -91,9 +91,6 @@ export class AppModule {
     this.materialCssVarsService.setWarnColor(StyleguideColors.warn);
     this.materialCssVarsService.setVariable(MaterialCssVariables.ForegroundText, StyleguideColors.foreground);
     this.materialCssVarsService.setVariable(MaterialCssVariables.ForegroundTextAlpha, '1');
-
-    // commented out because setDarkTheme overrides this
-    // bg colours are set in styles.scss using !important :(
-    // this.materialCssVarsService.setVariable(MaterialCssVariables.BackgroundBackground, StyleguideColors.background);
+    this.materialCssVarsService.setVariable(MaterialCssVariables.BackgroundBackground, StyleguideColors.background);
   }
 }

--- a/src/app/manage/media/media-overview/media-overview.component.html
+++ b/src/app/manage/media/media-overview/media-overview.component.html
@@ -1,9 +1,6 @@
-<div *ngIf="mediaList$ | async as mediaList"
-     class="mediaList">
-
-  <div *ngFor="let item of mediaList"
-       class="mediaList__clip">
-    <mat-card class="mediaList__clipCard">
+<div *ngIf="mediaList$ | async as mediaList">
+  <app-card-overview>
+    <app-overview-item *ngFor="let item of mediaList">
       <app-media-info (onAssignObs)="onAssignObs(item)"
                       (onDelete)="onDelete(item.id)"
                       (onEdit)="onEdit(item)"
@@ -14,22 +11,17 @@
       >
 
       </app-media-info>
-    </mat-card>
-  </div>
-  <ng-container *ngIf="mediaList.length === 0 || (screenList$ | async).length === 0 ">
-    <div [class.media-clip]="mediaList.length !== 0">
+    </app-overview-item>
+
+    <app-overview-item *ngIf="mediaList.length === 0 || (screenList$ | async).length === 0 ">
       <app-getting-started></app-getting-started>
-    </div>
-  </ng-container>
+    </app-overview-item>
 
+    <app-overview-add-item label="Add new media"
+    (click)="addNewItem()">
 
-  <div class="mediaList__clip">
-    <button (click)="addNewItem()"
-            class="mediaList__clipCard--addNew">
-      <mat-icon svgIcon="add"></mat-icon>
-      Add new media
-    </button>
-  </div>
+    </app-overview-add-item>
+  </app-card-overview>
 </div>
 
 <div class="floating-action-button">

--- a/src/app/manage/media/media-overview/media-overview.component.html
+++ b/src/app/manage/media/media-overview/media-overview.component.html
@@ -24,10 +24,11 @@
 
 
   <div class="mediaList__clip">
-    <mat-card (click)="addNewItem()" class="mediaList__clipCard mediaList__clipCard--addNew">
+    <button (click)="addNewItem()"
+            class="mediaList__clipCard--addNew">
       <mat-icon svgIcon="add"></mat-icon>
       Add new media
-    </mat-card>
+    </button>
   </div>
 </div>
 

--- a/src/app/manage/media/media-overview/media-overview.component.scss
+++ b/src/app/manage/media/media-overview/media-overview.component.scss
@@ -1,39 +1,6 @@
 @import '~angular-material-css-vars/public-util';
 @import '../../../../utils/mixins';
 
-.mediaList {
-  @include gridLayout;
-}
-
-.mediaList__clip {
-  @include gridLayout__item;
-}
-
-.mediaList__clipCard {
-  height: 100%;
-}
-
 .mediaList__appMediaInfo {
   height: 100%;
-}
-
-.mediaList__clipCard--addNew {
-  height: 100%;
-  width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: background-color 0.2s ease-in-out;
-  cursor: pointer;
-  background-color: #3F4855; //TODO HOW TO GET THIS VARIABLE
-  color: #ffffff; //TODO HOW TO GET THIS VARIABLE
-  font-size: 1.6rem;
-  border-color: transparent;
-  border-radius: 4px;
-  box-shadow: 0 2px 1px -1px rgba(0, 0, 0, 0.2), 0 1px 1px 0px rgba(0, 0, 0, 0.14), 0 1px 3px 0px rgba(0, 0, 0, 0.12);
-
-  &:hover, &:focus {
-    background-color: mat-css-color-accent() !important;
-    outline: 0;
-  }
 }

--- a/src/app/manage/media/media.module.ts
+++ b/src/app/manage/media/media.module.ts
@@ -1,26 +1,27 @@
-import {NgModule} from '@angular/core';
-import {CommonModule} from '@angular/common';
-import {MediaOverviewComponent} from './media-overview/media-overview.component';
-import {RouterModule, Routes} from "@angular/router";
-import {MatCardModule} from "@angular/material/card";
-import {MediaInfoComponent} from './media-overview/media-info/media-info.component';
-import {MatButtonModule} from "@angular/material/button";
-import {MatIconModule} from "@angular/material/icon";
-import {MediaTypePipe} from './media-overview/media-info/media-type.pipe';
-import {MatDialogModule} from "@angular/material/dialog";
-import {MatFormFieldModule} from "@angular/material/form-field";
-import {MatInputModule} from "@angular/material/input";
-import {MatSelectModule} from "@angular/material/select";
-import {MatSliderModule} from "@angular/material/slider";
-import {ReactiveFormsModule} from "@angular/forms";
-import {MatDividerModule} from "@angular/material/divider";
-import {ScreenAssigningDialogModule} from "./media-overview/screen-assigning-dialog/screen-assigning-dialog.module";
-import {ClipTypeModule} from "../../shared/components/clip-type/clip-type.module";
-import {MatListModule} from "@angular/material/list";
-import {GettingStartedModule} from "../../shared/components/getting-started/getting-started.module";
-import {ConfigMediaPathModule} from "./media-overview/config-media-path/config-media-path.module";
-import {MatChipsModule} from "@angular/material/chips";
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MediaOverviewComponent } from './media-overview/media-overview.component';
+import { RouterModule, Routes } from "@angular/router";
+import { MatCardModule } from "@angular/material/card";
+import { MediaInfoComponent } from './media-overview/media-info/media-info.component';
+import { MatButtonModule } from "@angular/material/button";
+import { MatIconModule } from "@angular/material/icon";
+import { MediaTypePipe } from './media-overview/media-info/media-type.pipe';
+import { MatDialogModule } from "@angular/material/dialog";
+import { MatFormFieldModule } from "@angular/material/form-field";
+import { MatInputModule } from "@angular/material/input";
+import { MatSelectModule } from "@angular/material/select";
+import { MatSliderModule } from "@angular/material/slider";
+import { ReactiveFormsModule } from "@angular/forms";
+import { MatDividerModule } from "@angular/material/divider";
+import { ScreenAssigningDialogModule } from "./media-overview/screen-assigning-dialog/screen-assigning-dialog.module";
+import { ClipTypeModule } from "../../shared/components/clip-type/clip-type.module";
+import { MatListModule } from "@angular/material/list";
+import { GettingStartedModule } from "../../shared/components/getting-started/getting-started.module";
+import { ConfigMediaPathModule } from "./media-overview/config-media-path/config-media-path.module";
+import { MatChipsModule } from "@angular/material/chips";
 import { PipesModule } from "../../core/pipes/pipes.module";
+import { CardOverviewModule } from "../../shared/components/card-overview/card-overview.module";
 
 const routes: Routes = [
   {
@@ -52,6 +53,7 @@ const routes: Routes = [
     GettingStartedModule,
     ConfigMediaPathModule,
     MatChipsModule,
+    CardOverviewModule,
   ]
 })
 export class MediaModule {}

--- a/src/app/manage/screen/screen-overview/clip-assigning-dialog/clip-assigning-dialog/clip-assigning-dialog.component.scss
+++ b/src/app/manage/screen/screen-overview/clip-assigning-dialog/clip-assigning-dialog/clip-assigning-dialog.component.scss
@@ -82,17 +82,12 @@
 .filterChip {
   cursor: pointer;
 }
+
 .iframe-container {
   .media-iframe-conatiner {
     width: 100%;
   }
 }
-
-.filterChip--selected {
-  background-color: red;
-}
-
-
 
 .svgContainer {
   height: 1.5rem;

--- a/src/app/manage/screen/screen-overview/screen-overview.component.html
+++ b/src/app/manage/screen/screen-overview/screen-overview.component.html
@@ -21,9 +21,9 @@
   </div>
 
   <div class="screensList__item">
-    <mat-card (click)="addNewItem()" class="screensList__item--addNew">
+    <button (click)="addNewItem()" class="screensList__item--addNew">
       <mat-icon svgIcon="add"></mat-icon>
       Add new screen
-    </mat-card>
+    </button>
   </div>
 </div>

--- a/src/app/manage/screen/screen-overview/screen-overview.component.scss
+++ b/src/app/manage/screen/screen-overview/screen-overview.component.scss
@@ -25,8 +25,15 @@
   justify-content: center;
   transition: background-color 0.2s ease-in-out;
   cursor: pointer;
+  background-color: #3F4855; //TODO HOW TO GET THIS VARIABLE
+  color: #ffffff; //TODO HOW TO GET THIS VARIABLE
+  font-size: 1.6rem;
+  border-color: transparent;
+  border-radius: 4px;
+  box-shadow: 0 2px 1px -1px rgba(0, 0, 0, 0.2), 0 1px 1px 0px rgba(0, 0, 0, 0.14), 0 1px 3px 0px rgba(0, 0, 0, 0.12);
 
-  &:hover {
+  &:hover, &:focus {
     background-color: mat-css-color-accent() !important;
+    outline: 0;
   }
 }

--- a/src/app/manage/settings/settings-overview/settings-overview.component.html
+++ b/src/app/manage/settings/settings-overview/settings-overview.component.html
@@ -1,5 +1,5 @@
 <div class="settingsList">
-  <mat-card>
+    <mat-card class="settingsList__item">
     <div class="title-row">
       <h2 class="mat-h2 title-name">Media folder</h2>
       <mat-icon svgIcon="folder"></mat-icon>
@@ -20,8 +20,7 @@
       </button>
     </div>
   </mat-card>
-
-  <mat-card>
+    <mat-card class="settingsList__item">
     <div class="title-row">
       <h2 class="mat-h2 title-name">Twitch Channel Name</h2>
       <app-twitch-icon></app-twitch-icon>

--- a/src/app/manage/settings/settings-overview/settings-overview.component.scss
+++ b/src/app/manage/settings/settings-overview/settings-overview.component.scss
@@ -4,6 +4,10 @@
   @include gridLayout;
 }
 
+.settingsList__item {
+  @include gridLayout__item;
+}
+
 .title-row {
   display: flex;
   flex-direction: row;
@@ -24,11 +28,16 @@
 
 .action-buttons {
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   justify-content: space-between;
 
   button {
-    width: 45%;
+    width: 100%;
+    margin-bottom: 1rem;
+
+    &:last-of-type {
+      margin-bottom: 0;
+    }
   }
 }
 

--- a/src/app/manage/settings/twitch-setting/twitch-setting.component.html
+++ b/src/app/manage/settings/twitch-setting/twitch-setting.component.html
@@ -1,10 +1,11 @@
   <form [formGroup]="form">
 
-    <div class="example-container">
+
       <mat-form-field >
         <mat-label>Account</mat-label>
         <input autocomplete="off" [readonly]="!editMode"
                formControlName="name" (keyup.enter)="save()"
+               class="twitchSetting__input"
                matInput required>
 
         <mat-error *ngIf="form.controls['name'].hasError('required')">
@@ -13,11 +14,11 @@
 
         <button (click)="toggleOrSave()" matSuffix
                 color="primary"
+                class="twitchSetting__button"
                 mat-raised-button>{{editMode ? 'Update' : 'Edit'}}</button>
 
       </mat-form-field>
 
 
-    </div>
   </form>
 

--- a/src/app/manage/settings/twitch-setting/twitch-setting.component.scss
+++ b/src/app/manage/settings/twitch-setting/twitch-setting.component.scss
@@ -1,0 +1,12 @@
+.twitchSetting__input[readonly] {
+  opacity: 0.3;
+}
+
+.twitchSetting__button {
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.mat-form-field {
+  display: block;
+}

--- a/src/app/manage/twitch/events-overview/add-event/add-event.component.css
+++ b/src/app/manage/twitch/events-overview/add-event/add-event.component.css
@@ -1,6 +1,5 @@
 :host {
   display: block;
-  background: #444;
 }
 
 form {

--- a/src/app/manage/twitch/events-overview/add-event/add-event.component.html
+++ b/src/app/manage/twitch/events-overview/add-event/add-event.component.html
@@ -34,7 +34,12 @@
 </form>
 -->
 
+<!--
+ Ideally we need to make this consistent with screen overview and
+ media overview 'add new' - so can we remove the button within a button?
+-->
 
 <button (click)="triggerAdd()" color="primary"
-        mat-flat-button>Add
+        mat-flat-button>
+  <mat-icon svgIcon="add"></mat-icon> Add New Event
 </button>

--- a/src/app/manage/twitch/events-overview/event-info/event-info.component.css
+++ b/src/app/manage/twitch/events-overview/event-info/event-info.component.css
@@ -1,7 +1,0 @@
-:host {
-  display: block;
-  background: #555;
-  border: 1px solid white;
-  border-radius: 1rem;
-  padding: 0.5rem;
-}

--- a/src/app/manage/twitch/events-overview/event-info/event-info.component.html
+++ b/src/app/manage/twitch/events-overview/event-info/event-info.component.html
@@ -1,26 +1,48 @@
+<div class="eventInfo__titleRow">
+  <h2 class="mat-h2 eventInfo__titleRow__name">
+    <span class="eventInfo__titleRow__event">
+      {{ item.event }}:
+    </span>
+    {{item.name}}
+  </h2>
+</div>
 
-<mat-checkbox [checked]="item.active" (change)="onActiveChanged($event)"></mat-checkbox>
+<div class="eventInfo__checkbox">
+  <mat-chip-list>
+    <mat-chip class="eventInfo__chip"
+              [class.eventInfo__chip--selected]="item.active">
+      <mat-checkbox [checked]="item.active" (change)="onActiveChanged($event)">
+        {{item.active ? 'Event active' : 'Event inactive'}}
+      </mat-checkbox>
+    </mat-chip>
+  </mat-chip-list>
+</div>
 
+<div class="eventInfo__actionButtons">
+  <button (click)="onEdit.emit()" color="accent" mat-flat-button>
+    <mat-icon svgIcon="edit"></mat-icon>
+    Edit
+  </button>
+  <button (click)="onPreview.emit()" color="primary" mat-button>
+    <mat-icon svgIcon="preview"></mat-icon>
+    Preview
+  </button>
+</div>
 
-<b>{{item.name}}</b> - Event: <strong>{{ item.event }}</strong> -
+<div class="eventInfo__meta">
+  <ng-container *ngIf="allInformations$ | async as information">
 
-<ng-container *ngIf="allInformations$ | async as information">
+    <p>Clip: {{ information.clip?.name }}</p>
+    <!-- Screen: <strong>{{ information.screen.name }}</strong> -->
+    <!-- it would be SUPER AMAZING to have a preview of the media here! -->
 
-  Clip: <strong>{{ information.clip?.name }}</strong>
-  <!-- Screen: <strong>{{ information.screen.name }}</strong> -->
+  </ng-container>
+</div>
 
-</ng-container>
+<mat-card-actions>
+  <button (click)="onDelete.emit()" class="eventInfo__delete" color="warn" mat-flat-button>
+    <mat-icon svgIcon="delete"></mat-icon>
+    Delete event
+  </button>
+</mat-card-actions>
 
-<button (click)="onPreview.emit()" color="primary" mat-button>
-  <mat-icon svgIcon="preview"></mat-icon>
-  Preview
-</button>
-
-<button (click)="onDelete.emit()" color="warn" mat-icon-button>
-  <mat-icon svgIcon="delete"></mat-icon>
-</button>
-
-
-<button (click)="onEdit.emit()" color="accent" mat-icon-button>
-  <mat-icon svgIcon="edit"></mat-icon>
-</button>

--- a/src/app/manage/twitch/events-overview/event-info/event-info.component.scss
+++ b/src/app/manage/twitch/events-overview/event-info/event-info.component.scss
@@ -1,0 +1,73 @@
+@import '~angular-material-css-vars/public-util';
+
+:host {
+  width: 100%;
+
+  ::ng-deep .mat-checkbox-background {
+    background-color: transparent !important;
+  }
+
+  ::ng-deep .mat-chip {
+    &.mat-chip.mat-standard-chip {
+      background-color: #2f3640;
+      &.eventInfo__chip--selected {
+        background-color: #0be881; //TODO - make a var
+        color: #2f3640; //TODO - make a var
+
+        .mat-checkbox-frame {
+          border-color: #2f3640;
+        }
+      }
+    }
+  }
+}
+
+.eventInfo__checkbox {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+
+.eventInfo__titleRow {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  align-content: center;
+  justify-content: space-between;
+  margin-bottom: 2rem;
+}
+
+.eventInfo__titleRow__name {
+  margin-bottom: 0;
+}
+
+.eventInfo__chip {
+  cursor: pointer;
+}
+
+.eventInfo__titleRow__event {
+  text-transform: capitalize;
+}
+
+.eventInfo__meta {
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+}
+
+.eventInfo__actionButtons {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+
+  button {
+    width: 45%;
+  }
+}
+
+.eventInfo__delete {
+  margin-left: auto;
+  margin-right: auto;
+  display: block;
+}
+

--- a/src/app/manage/twitch/events-overview/event-info/event-info.component.ts
+++ b/src/app/manage/twitch/events-overview/event-info/event-info.component.ts
@@ -8,7 +8,7 @@ import {AppService} from "../../../../state/app.service";
 @Component({
   selector: 'app-event-info',
   templateUrl: './event-info.component.html',
-  styleUrls: ['./event-info.component.css']
+  styleUrls: ['./event-info.component.scss']
 })
 export class EventInfoComponent implements OnInit {
 

--- a/src/app/manage/twitch/events-overview/events-overview.component.css
+++ b/src/app/manage/twitch/events-overview/events-overview.component.css
@@ -1,8 +1,0 @@
-app-add-event {
-}
-
-app-event-info {
-  margin-left: 0.5rem;
-  margin-right: 0.5rem;
-  margin-top: 1rem;
-}

--- a/src/app/manage/twitch/events-overview/events-overview.component.html
+++ b/src/app/manage/twitch/events-overview/events-overview.component.html
@@ -1,9 +1,16 @@
-<app-add-event (added)="newEventConfigReceived($event)"></app-add-event>
 
-<app-event-info (onDelete)="deleteEvent(item.id)"
-                (onEdit)="editEvent(item)"
-                (onPreview)="previewEvent(item)"
-                *ngFor="let item of eventsList$ | async"
-                [item]="item"
->
-</app-event-info>
+<div class="eventsList">
+  <mat-card *ngFor="let item of eventsList$ | async"
+       class="eventsList__item">
+    <app-event-info (onDelete)="deleteEvent(item.id)"
+                    (onEdit)="editEvent(item)"
+                    (onPreview)="previewEvent(item)"
+                    [item]="item"
+    >
+    </app-event-info>
+  </mat-card>
+  <button class="eventsList__item--addNew">
+    <app-add-event (added)="newEventConfigReceived($event)"></app-add-event>
+  </button>
+</div>
+

--- a/src/app/manage/twitch/events-overview/events-overview.component.scss
+++ b/src/app/manage/twitch/events-overview/events-overview.component.scss
@@ -1,23 +1,14 @@
-@import '~angular-material-css-vars/public-util';
 @import '../../../../utils/mixins';
 
-.mediaList {
+.eventsList {
   @include gridLayout;
 }
 
-.mediaList__clip {
+.eventsList__item {
   @include gridLayout__item;
 }
 
-.mediaList__clipCard {
-  height: 100%;
-}
-
-.mediaList__appMediaInfo {
-  height: 100%;
-}
-
-.mediaList__clipCard--addNew {
+.eventsList__item--addNew {
   height: 100%;
   width: 100%;
   display: flex;

--- a/src/app/manage/twitch/events-overview/events-overview.component.ts
+++ b/src/app/manage/twitch/events-overview/events-overview.component.ts
@@ -9,7 +9,7 @@ import {HttpClient} from "@angular/common/http";
 @Component({
   selector: 'app-events-overview',
   templateUrl: './events-overview.component.html',
-  styleUrls: ['./events-overview.component.css']
+  styleUrls: ['./events-overview.component.scss']
 })
 export class EventsOverviewComponent implements OnInit {
 

--- a/src/app/manage/twitch/twitch.module.ts
+++ b/src/app/manage/twitch/twitch.module.ts
@@ -12,6 +12,7 @@ import {MatDialogModule} from "@angular/material/dialog";
 import {MatInputModule} from "@angular/material/input";
 import {MatCheckboxModule} from "@angular/material/checkbox";
 import {MatCardModule} from "@angular/material/card";
+import {MatChipsModule} from "@angular/material/chips";
 
 const routes: Routes = [
   {
@@ -33,6 +34,7 @@ const routes: Routes = [
     MatInputModule,
     MatCheckboxModule,
     MatCardModule,
+    MatChipsModule,
   ]
 })
 export class TwitchModule {

--- a/src/app/manage/twitch/twitch.module.ts
+++ b/src/app/manage/twitch/twitch.module.ts
@@ -11,7 +11,7 @@ import {MatIconModule} from "@angular/material/icon";
 import {MatDialogModule} from "@angular/material/dialog";
 import {MatInputModule} from "@angular/material/input";
 import {MatCheckboxModule} from "@angular/material/checkbox";
-
+import {MatCardModule} from "@angular/material/card";
 
 const routes: Routes = [
   {
@@ -32,6 +32,7 @@ const routes: Routes = [
     MatDialogModule,
     MatInputModule,
     MatCheckboxModule,
+    MatCardModule,
   ]
 })
 export class TwitchModule {

--- a/src/app/shared/components/card-overview/card-overview.component.html
+++ b/src/app/shared/components/card-overview/card-overview.component.html
@@ -1,0 +1,1 @@
+<ng-content></ng-content>

--- a/src/app/shared/components/card-overview/card-overview.component.scss
+++ b/src/app/shared/components/card-overview/card-overview.component.scss
@@ -1,0 +1,16 @@
+:host {
+  --grid-padding: 2rem;
+
+  display: grid;
+  padding: var(--grid-padding);
+
+  @media screen and (min-width: 620px) {
+    grid-template-columns: 1fr 1fr;
+    grid-column-gap: var(--grid-padding);
+  }
+
+  @media screen and (min-width: 930px) {
+    grid-template-columns: 1fr 1fr 1fr;
+    grid-column-gap: var(--grid-padding);
+  }
+}

--- a/src/app/shared/components/card-overview/card-overview.component.spec.ts
+++ b/src/app/shared/components/card-overview/card-overview.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CardOverviewComponent } from './card-overview.component';
+
+describe('CardOverviewComponent', () => {
+  let component: CardOverviewComponent;
+  let fixture: ComponentFixture<CardOverviewComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ CardOverviewComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CardOverviewComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/card-overview/card-overview.component.ts
+++ b/src/app/shared/components/card-overview/card-overview.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-card-overview',
+  templateUrl: './card-overview.component.html',
+  styleUrls: ['./card-overview.component.scss']
+})
+export class CardOverviewComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/shared/components/card-overview/card-overview.module.ts
+++ b/src/app/shared/components/card-overview/card-overview.module.ts
@@ -1,0 +1,23 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { CardOverviewComponent } from './card-overview.component';
+import { OverviewItemComponent } from './overview-item/overview-item.component';
+import { OverviewAddItemComponent } from './overview-add-item/overview-add-item.component';
+import { MatCardModule } from "@angular/material/card";
+import { MatIconModule } from "@angular/material/icon";
+
+
+@NgModule({
+  declarations: [CardOverviewComponent, OverviewItemComponent, OverviewAddItemComponent],
+  exports: [
+    CardOverviewComponent,
+    OverviewItemComponent,
+    OverviewAddItemComponent
+  ],
+  imports: [
+    CommonModule,
+    MatCardModule,
+    MatIconModule
+  ]
+})
+export class CardOverviewModule { }

--- a/src/app/shared/components/card-overview/overview-add-item/overview-add-item.component.html
+++ b/src/app/shared/components/card-overview/overview-add-item/overview-add-item.component.html
@@ -1,0 +1,4 @@
+<button>
+   <mat-icon svgIcon="add"></mat-icon>
+  {{label}}
+</button>

--- a/src/app/shared/components/card-overview/overview-add-item/overview-add-item.component.scss
+++ b/src/app/shared/components/card-overview/overview-add-item/overview-add-item.component.scss
@@ -1,0 +1,26 @@
+:host {
+  width: 100%;
+  height: 100%;
+  margin-bottom: var(--grid-padding);
+}
+
+button {
+  height: 100%;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.2s ease-in-out;
+  cursor: pointer;
+  background-color: var(--card-background-color);
+  color: var(--palette-foreground-text);
+  font-size: 1.6rem;
+  border-color: transparent;
+  border-radius: 4px;
+  box-shadow: 0 2px 1px -1px rgba(0, 0, 0, 0.2), 0 1px 1px 0px rgba(0, 0, 0, 0.14), 0 1px 3px 0px rgba(0, 0, 0, 0.12);
+
+  &:hover, &:focus {
+    background-color: mat-css-color-accent() !important;
+    outline: 0;
+  }
+}

--- a/src/app/shared/components/card-overview/overview-add-item/overview-add-item.component.scss
+++ b/src/app/shared/components/card-overview/overview-add-item/overview-add-item.component.scss
@@ -1,3 +1,5 @@
+@import '~angular-material-css-vars/public-util';
+
 :host {
   width: 100%;
   height: 100%;

--- a/src/app/shared/components/card-overview/overview-add-item/overview-add-item.component.spec.ts
+++ b/src/app/shared/components/card-overview/overview-add-item/overview-add-item.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { OverviewAddItemComponent } from './overview-add-item.component';
+
+describe('OverviewAddItemComponent', () => {
+  let component: OverviewAddItemComponent;
+  let fixture: ComponentFixture<OverviewAddItemComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ OverviewAddItemComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(OverviewAddItemComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/card-overview/overview-add-item/overview-add-item.component.ts
+++ b/src/app/shared/components/card-overview/overview-add-item/overview-add-item.component.ts
@@ -1,0 +1,18 @@
+import { Component, Input, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-overview-add-item',
+  templateUrl: './overview-add-item.component.html',
+  styleUrls: ['./overview-add-item.component.scss']
+})
+export class OverviewAddItemComponent implements OnInit {
+
+  @Input()
+  public label = '';
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/shared/components/card-overview/overview-item/overview-item.component.html
+++ b/src/app/shared/components/card-overview/overview-item/overview-item.component.html
@@ -1,0 +1,3 @@
+<mat-card>
+  <ng-content></ng-content>
+</mat-card>

--- a/src/app/shared/components/card-overview/overview-item/overview-item.component.scss
+++ b/src/app/shared/components/card-overview/overview-item/overview-item.component.scss
@@ -1,0 +1,9 @@
+:host {
+  width: 100%;
+  height: 100%;
+  margin-bottom: var(--grid-padding);
+}
+
+mat-card {
+  height: 100%;
+}

--- a/src/app/shared/components/card-overview/overview-item/overview-item.component.spec.ts
+++ b/src/app/shared/components/card-overview/overview-item/overview-item.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { OverviewItemComponent } from './overview-item.component';
+
+describe('OverviewItemComponent', () => {
+  let component: OverviewItemComponent;
+  let fixture: ComponentFixture<OverviewItemComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ OverviewItemComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(OverviewItemComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/card-overview/overview-item/overview-item.component.ts
+++ b/src/app/shared/components/card-overview/overview-item/overview-item.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-overview-item',
+  templateUrl: './overview-item.component.html',
+  styleUrls: ['./overview-item.component.scss']
+})
+export class OverviewItemComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/shared/components/dialogs/twitch-edit/twitch-edit.component.html
+++ b/src/app/shared/components/dialogs/twitch-edit/twitch-edit.component.html
@@ -5,9 +5,10 @@
 
     <div class="example-container">
       <mat-form-field appearance="outline">
-        <mat-label>Name</mat-label>
+        <mat-label>Event Name</mat-label>
         <input autocomplete="off"
                formControlName="name"
+               placeholder="Raided by whitep4nth3r"
                matInput>
       </mat-form-field>
 
@@ -16,7 +17,7 @@
 
     <div class="example-container">
       <mat-form-field appearance="outline">
-        <mat-label>Twitch Event</mat-label>
+        <mat-label>Twitch Event Type</mat-label>
         <mat-select [required]="true"
                     formControlName="event">
           <mat-option *ngFor="let item of twitchEvents"
@@ -28,10 +29,20 @@
 
     </div>
 
+    <div class="example-container">
+      <mat-form-field appearance="outline">
+        <mat-label>Message text to trigger event</mat-label>
+        <input autocomplete="off"
+               formControlName="contains"
+               placeholder="!wow"
+               matInput>
+      </mat-form-field>
+    </div>
+
 
     <div class="example-container">
       <mat-form-field appearance="outline">
-        <mat-label>Meme</mat-label>
+        <mat-label>Select media</mat-label>
         <mat-select [required]="true"
                     formControlName="clipId">
 
@@ -46,14 +57,7 @@
       </mat-form-field>
     </div>
 
-    <div class="example-container">
-      <mat-form-field appearance="outline">
-        <mat-label>Contains</mat-label>
-        <input autocomplete="off"
-               formControlName="contains"
-               matInput>
-      </mat-form-field>
-    </div>
+
   </form>
 </mat-dialog-content>
 
@@ -62,6 +66,6 @@
   <button mat-button mat-dialog-close>Cancel</button>
   <button (click)="save()" cdkFocusInitial
           color="primary"
-          mat-raised-button>{{ data.id ? 'Update' : 'Add' }}</button>
+          mat-raised-button>{{ data.id ? 'Update Event' : 'Add Event' }}</button>
 </mat-dialog-actions>
 

--- a/src/app/shared/components/dialogs/twitch-edit/twitch-edit.component.scss
+++ b/src/app/shared/components/dialogs/twitch-edit/twitch-edit.component.scss
@@ -3,3 +3,7 @@
   min-width: 400px;
   max-width: 600px;
 }
+
+.mat-form-field {
+  display: block;
+}

--- a/src/app/shared/components/dialogs/twitch-edit/twitch-edit.component.ts
+++ b/src/app/shared/components/dialogs/twitch-edit/twitch-edit.component.ts
@@ -9,9 +9,9 @@ import {SnackbarService} from "../../../../core/services/snackbar.service";
 
 // TODO better class/interface name?
 const INITIAL_TWITCH: Partial<Twitch> = {
-  name: 'Your Twitch Event', // TODO better default value
+  name: '',
   event: TwitchEventTypes.message,
-  contains: '!wow',
+  contains: '',
   active: true
 };
 

--- a/src/app/shared/components/getting-started/getting-started.component.html
+++ b/src/app/shared/components/getting-started/getting-started.component.html
@@ -1,4 +1,4 @@
-<mat-card *ngIf="(mediaList$ |async).length === 0 || (screenList$ | async).length  === 0">
+<ng-container *ngIf="(mediaList$ |async).length === 0 || (screenList$ | async).length  === 0">
   <mat-card-title>
     Getting started:
   </mat-card-title>
@@ -48,6 +48,6 @@
     </mat-list>
 
   </mat-card-content>
-</mat-card>
+</ng-container>
 
 <div>Remove 'add media' block to right right of this when there is no media and we are in onboarding mode</div>

--- a/src/app/shared/styleguide/styleguide.component.ts
+++ b/src/app/shared/styleguide/styleguide.component.ts
@@ -1,9 +1,11 @@
-import {Component, OnInit} from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 
 export const StyleguideColors = {
-  background: '#2f3640', // todo add custom css var
+  // var(--palette-background-background)
+  background: '#2f3640',
   foreground: '#ffffff',
   primary: '#4bcffa',
+  // mat-css-color-accent()
   accent: '#575fcf',
   warn: '#f53b57',
   highlight: '#00d8d6', // todo add custom css var

--- a/src/css-var-colors.scss
+++ b/src/css-var-colors.scss
@@ -1,0 +1,14 @@
+@mixin list-colors(){
+  /**
+    * Material CSS-VAR Colors, examples:
+    * - mat-css-color-accent()
+    * - rgb(var(--palette-background-background))  // or other --palette-**
+    *
+    * to override material-css-vars look at AppModule.constructor
+    *
+    * The following colors are not one of the overwritten material-css-var
+    *
+    */
+
+    --card-background-color: #3F4855;
+}

--- a/src/css-var-colors.scss
+++ b/src/css-var-colors.scss
@@ -3,6 +3,7 @@
     * Material CSS-VAR Colors, examples:
     * - mat-css-color-accent()
     * - rgb(var(--palette-background-background))  // or other --palette-**
+    * - var(--palette-foreground-text) .... some are with var / some with rgb(var())
     *
     * to override material-css-vars look at AppModule.constructor
     *

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -38,6 +38,10 @@ $custom-typography: mat-typography-config(
   .mat-app-background {
     background-color: var(--palette-background-background) !important;
   }
+
+  .navigation {
+    background-color: var(--palette-background-background) !important;
+  }
 };
 
 .max-height-dialog {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -2,6 +2,7 @@
 @import '~angular-material-css-vars/main';
 @import url('https://fonts.googleapis.com/css2?family=Barlow:wght@400;700&display=swap');
 @import '~animate.css/animate.css';
+@import './css-var-colors';
 
 
 // optional
@@ -35,7 +36,7 @@ $custom-typography: mat-typography-config(
 
 @include init-material-css-vars($typography-config: $custom-typography) {
   .mat-app-background {
-    background-color: var(--palette-background-background);
+    background-color: var(--palette-background-background) !important;
   }
 };
 
@@ -45,9 +46,12 @@ $custom-typography: mat-typography-config(
   }
 }
 
+:root {
+  @include list-colors();
+}
+
 body {
   font-size: 16px;
-  background-color: #2f3640 !important;
   font-family: Barlow, sans-serif;
 }
 
@@ -59,10 +63,8 @@ body {
 }
 
 .isDarkTheme {
-  --palette-background-background: 47, 54, 64;
-
   .mat-card {
-    background-color: #3F4855 !important;
+    background-color: var(--card-background-color) !important;
   }
 
   .mat-table {
@@ -74,7 +76,7 @@ body {
   }
 
   .mat-chip.mat-standard-chip {
-    background-color: #3F4855;
+    background-color: var(--card-background-color);
     color: white;
     font-family: Barlow, sans-serif;
   }

--- a/src/utils/mixins.scss
+++ b/src/utils/mixins.scss
@@ -15,5 +15,6 @@
 
 @mixin gridLayout__item {
   width: 100%;
+  height: 100%;
   margin-bottom: 2rem;
 }


### PR DESCRIPTION
## Accessibility fix:

The 'add new' cards on the media and screens overviews are now buttons so the user can keyboard-tab to the action and press enter to trigger

## Layout changes

1. Added grid view to /manage/twitch and attempted to lay the cards out in the same way as the media and screens overview
2. Fixed some layout issues with the buttons on /manage/settings
3. Removed some old code (i.e. background-color: red)

## Outstanding issues to consider

1. Can we have a preview of the clip as an i.e. image on the twitch event info?
2. I can't work out how to use the css/Sass vars for material design - so I have left TODOs on the appropriate Sass files
3. The 'add new' twitch event - ideally we need to make this consistent with screen overview and
 media overview 'add new' - so can we remove the button within a button?


