### PR TITLE
Fix: The styling in the media chooser has been repaired

### DIFF
--- a/src/app/shared/dialogs/clip-assigning-dialog/clip-assigning-dialog.component.html
+++ b/src/app/shared/dialogs/clip-assigning-dialog/clip-assigning-dialog.component.html
@@ -12,7 +12,7 @@
         [class.mediaList__option--selected]="checkedMap[clip.id]"
         class="mediaList__option animate__animated  animate__fadeIn"
     >
-      <figure *ngIf="clip.type === 0">
+      <figure *ngIf="clip.type === MediaType.Picture">
         <figcaption class="mediaList__name">
           <app-clip-type [type]="clip.type"
                          class="mediaList__icon"

--- a/src/app/shared/dialogs/clip-assigning-dialog/clip-assigning-dialog.component.html
+++ b/src/app/shared/dialogs/clip-assigning-dialog/clip-assigning-dialog.component.html
@@ -8,28 +8,30 @@
 
   <ol class="mediaList">
     <li (click)="clickToSelect(clip)"
-        *ngFor="let clip of clips$|async; trackBy: trackByClip"
+        *ngFor="let clip of clips$ | async; trackBy: trackByClip"
         [class.mediaList__option--selected]="checkedMap[clip.id]"
-        class="mediaList__option animate__animated  animate__fadeIn">
+        class="mediaList__option animate__animated  animate__fadeIn"
+    >
       <figure *ngIf="clip.type === 0">
         <figcaption class="mediaList__name">
           <app-clip-type [type]="clip.type"
                          class="mediaList__icon"
                          matListIcon>
-
           </app-clip-type>
-          {{clip.name}}</figcaption>
-        <img [alt]="clip.name" [src]="clip | mediaToUrl" class="mediaList__img"/>
+
+          <span>{{clip.name}}</span>
+        </figcaption>
+        <img [alt]="clip.name" [src]="clip | mediaToUrl" class="mediaList__img" />
       </figure>
 
-      <span *ngIf="clip.type === 1" class="mediaList__audioContainer">
+      <span *ngIf="clip.type === MediaType.Audio" class="mediaList__audioContainer">
         <span class="mediaList__name">
            <app-clip-type [type]="clip.type"
                           class="mediaList__icon"
                           matListIcon>
+           </app-clip-type>
 
-            </app-clip-type>
-          {{clip.name}}
+           <span>{{clip.name}}</span>
         </span>
 
         <span class="audio-image">
@@ -37,14 +39,14 @@
         </span>
       </span>
 
-      <span *ngIf="clip.type === 2" class="mediaList__videoContainer">
+      <span *ngIf="clip.type === MediaType.Video" class="mediaList__videoContainer">
           <span class="mediaList__name">
             <app-clip-type [type]="clip.type"
                            class="mediaList__icon"
                            matListIcon>
-
             </app-clip-type>
-            {{clip.name}}
+
+            <span>{{clip.name}}</span>
         </span>
 
         <span class="video-image">
@@ -52,47 +54,48 @@
         </span>
       </span>
 
-      <span *ngIf="clip.type === 3" class="iframe-container">
+      <span *ngIf="clip.type === MediaType.IFrame" class="iframe-container">
         <span class="media-name">
            <app-clip-type [type]="clip.type"
                           class="mediaList__icon"
                           matListIcon>
+           </app-clip-type>
 
-            </app-clip-type>
-          {{ clip.name }}
+           <span>{{clip.name}}</span>
         </span>
+
         <span class="media-iframe-container">
           <app-clip-type [type]="clip.type"
-                          class="mediaList__icon"
-                          iconSize="6rem"
-                          matListIcon>
-
+                         class="mediaList__icon"
+                         iconSize="6rem"
+                         matListIcon>
             </app-clip-type>
         </span>
       </span>
 
 
-      <span *ngIf="clip.type === 4" class="iframe-container">
+      <span *ngIf="clip.type === MediaType.HTML" class="iframe-container">
         <span class="media-name">
            <app-clip-type [type]="clip.type"
                           class="mediaList__icon"
                           matListIcon>
+           </app-clip-type>
 
-            </app-clip-type>
-          {{ clip.name }}
+           <span>{{clip.name}}</span>
         </span>
-        <span class="media-iframe-container">
-        </span>
+
+        <span class="media-iframe-container"></span>
       </span>
 
-      <span *ngIf="clip.type === 100" class="mediaList__videoContainer">
+      <span *ngIf="clip.type === MediaType.Meta" class="mediaList__videoContainer">
           <span class="mediaList__name">
             <app-clip-type [type]="clip.type"
                            class="mediaList__icon"
                            matListIcon>
 
             </app-clip-type>
-            {{clip.name}}
+
+            <span>{{clip.name}}</span>
         </span>
 
         <span class="video-image">

--- a/src/app/shared/dialogs/clip-assigning-dialog/clip-assigning-dialog.component.html
+++ b/src/app/shared/dialogs/clip-assigning-dialog/clip-assigning-dialog.component.html
@@ -13,95 +13,95 @@
         class="mediaList__option animate__animated  animate__fadeIn"
     >
       <figure *ngIf="clip.type === MediaType.Picture">
-        <figcaption class="mediaList__name">
+        <figcaption class="mediaList__header">
           <app-clip-type [type]="clip.type"
                          class="mediaList__icon"
                          matListIcon>
           </app-clip-type>
 
-          <span>{{clip.name}}</span>
+          <span class="mediaList__header__name">{{clip.name}}</span>
         </figcaption>
         <img [alt]="clip.name" [src]="clip | mediaToUrl" class="mediaList__img" />
       </figure>
 
-      <span *ngIf="clip.type === MediaType.Audio" class="mediaList__audioContainer">
-        <span class="mediaList__name">
-           <app-clip-type [type]="clip.type"
-                          class="mediaList__icon"
-                          matListIcon>
-           </app-clip-type>
+      <div *ngIf="clip.type === MediaType.Audio" class="mediaList__audioContainer">
+        <div class="mediaList__header">
+          <app-clip-type [type]="clip.type"
+                         class="mediaList__icon"
+                         matListIcon>
+          </app-clip-type>
 
-           <span>{{clip.name}}</span>
-        </span>
+          <span class="mediaList__header__name">{{clip.name}}</span>
+        </div>
 
-        <span class="audio-image">
+        <div class="audio-image">
           <mat-icon matListIcon svgIcon="speaker"></mat-icon>
-        </span>
-      </span>
+        </div>
+      </div>
 
-      <span *ngIf="clip.type === MediaType.Video" class="mediaList__videoContainer">
-          <span class="mediaList__name">
-            <app-clip-type [type]="clip.type"
-                           class="mediaList__icon"
-                           matListIcon>
-            </app-clip-type>
+      <div *ngIf="clip.type === MediaType.Video" class="mediaList__videoContainer">
+        <div class="mediaList__header">
+          <app-clip-type [type]="clip.type"
+                         class="mediaList__icon"
+                         matListIcon>
+          </app-clip-type>
 
-            <span>{{clip.name}}</span>
-        </span>
+          <span class="mediaList__header__name">{{clip.name}}</span>
+        </div>
 
-        <span class="video-image">
+        <div class="video-image">
           <mat-icon matListIcon svgIcon="video_library"></mat-icon>
-        </span>
-      </span>
+        </div>
+      </div>
 
-      <span *ngIf="clip.type === MediaType.IFrame" class="iframe-container">
-        <span class="media-name">
-           <app-clip-type [type]="clip.type"
-                          class="mediaList__icon"
-                          matListIcon>
-           </app-clip-type>
+      <div *ngIf="clip.type === MediaType.IFrame" class="iframe-container">
+        <div class="mediaList__header">
+          <app-clip-type [type]="clip.type"
+                         class="mediaList__icon"
+                         matListIcon>
+          </app-clip-type>
 
-           <span>{{clip.name}}</span>
-        </span>
+          <span class="mediaList__header__name">{{clip.name}}</span>
+        </div>
 
-        <span class="media-iframe-container">
+        <div class="media-iframe-container">
           <app-clip-type [type]="clip.type"
                          class="mediaList__icon"
                          iconSize="6rem"
                          matListIcon>
-            </app-clip-type>
-        </span>
-      </span>
+          </app-clip-type>
+        </div>
+      </div>
 
 
-      <span *ngIf="clip.type === MediaType.HTML" class="iframe-container">
-        <span class="media-name">
-           <app-clip-type [type]="clip.type"
-                          class="mediaList__icon"
-                          matListIcon>
-           </app-clip-type>
+      <div *ngIf="clip.type === MediaType.HTML" class="iframe-container">
+        <div class="mediaList__header">
+          <app-clip-type [type]="clip.type"
+                         class="mediaList__icon"
+                         matListIcon>
+          </app-clip-type>
 
-           <span>{{clip.name}}</span>
-        </span>
+          <span class="mediaList__header__name">{{clip.name}}</span>
+        </div>
 
-        <span class="media-iframe-container"></span>
-      </span>
+        <div class="media-iframe-container"></div>
+      </div>
 
-      <span *ngIf="clip.type === MediaType.Meta" class="mediaList__videoContainer">
-          <span class="mediaList__name">
-            <app-clip-type [type]="clip.type"
-                           class="mediaList__icon"
-                           matListIcon>
+      <div *ngIf="clip.type === MediaType.Meta" class="mediaList__videoContainer">
+        <div class="mediaList__header">
+          <app-clip-type [type]="clip.type"
+                         class="mediaList__icon"
+                         matListIcon>
 
-            </app-clip-type>
+          </app-clip-type>
 
-            <span>{{clip.name}}</span>
-        </span>
+          <span class="mediaList__header__name">{{clip.name}}</span>
+        </div>
 
-        <span class="video-image">
+        <div class="video-image">
           <mat-icon matListIcon svgIcon="art_track"></mat-icon>
-        </span>
-      </span>
+        </div>
+      </div>
     </li>
   </ol>
 </div>

--- a/src/app/shared/dialogs/clip-assigning-dialog/clip-assigning-dialog.component.scss
+++ b/src/app/shared/dialogs/clip-assigning-dialog/clip-assigning-dialog.component.scss
@@ -55,13 +55,16 @@
   width: 100%;
 }
 
-.mediaList__name {
+.mediaList__header {
   display: flex;
   align-items: center;
   margin-bottom: 0.5rem;
 
-  overflow: hidden;
-  white-space: nowrap;
+  &__name {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
 }
 
 .mediaList__icon {


### PR DESCRIPTION
Fixes #248 

I also removed magic numbers in favor of enum values.

Additionally there were two classes missing (maybe a prior rename error), which was acutally the reason for the messed up styles in the first place.

Also there was a bit of a mess with mixins spans and divs, but it kinda worked because the span was actually `display: flex`. So i made everything a div and added a new class to differentiate.