### PR TITLE
Add content type header for file preview endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -121,7 +121,7 @@
         "core-js": "3.6.5",
         "cpy-cli": "3.1.1",
         "cross-env": "7.0.2",
-        "cypress": "*",
+        "cypress": "latest",
         "electron": "11.5.0",
         "electron-builder": "22.9.1",
         "electron-reload": "1.5.0",

--- a/server/controllers/file.controller.ts
+++ b/server/controllers/file.controller.ts
@@ -63,7 +63,9 @@ export class FileController {
       //return loadedFile
       response.header({
         'Content-type': contentType
-      }).status(200).send(loadedFile);
+      });
+
+      return loadedFile;
     }
 
     throw new NotFound('no media file found');
@@ -97,7 +99,9 @@ export class FileController {
       //return loadedFile
       response.header({
         'Content-type': contentType
-      }).status(200).send(loadedFile);
+      });
+
+      return loadedFile;
     }
 
     throw new NotFound('no media file found');
@@ -134,7 +138,9 @@ export class FileController {
       //return loadedFile
       response.header({
         'Content-type': contentType
-      }).status(200).send(loadedFile);
+      });
+
+      return loadedFile;
     }
 
     throw new NotFound('no media file found');
@@ -153,18 +159,24 @@ export class FileController {
      * image/svg+xml
      */
     let contentType = 'image/jpeg';
-    switch (path.extname(fileName?.toLowerCase() ?? '')) {
-      case 'jpg':
-      case 'jpeg':
+    const extension = path.extname(fileName ?? '');
+    console.log(fileName, extension);
+    switch (extension.toLowerCase()) {
+      case '.jpg':
+      case '.jpeg':
         contentType = 'image/jpeg';
         break;
 
-      case 'png':
+      case '.png':
         contentType = 'image/png';
         break;
 
-      case 'gif':
+      case '.gif':
         contentType = 'image/gif';
+        break;
+
+      case '.webp':
+        contentType = 'image/webp';
         break;
     }
 

--- a/server/controllers/file.controller.ts
+++ b/server/controllers/file.controller.ts
@@ -60,7 +60,6 @@ export class FileController {
 
       const contentType = this._getContentTypeFromExtension(filename);
 
-      //return loadedFile
       response.header({
         'Content-type': contentType
       });
@@ -96,7 +95,6 @@ export class FileController {
       const loadedFile = fs.readFileSync(filename);
       const contentType = this._getContentTypeFromExtension(filename);
 
-      //return loadedFile
       response.header({
         'Content-type': contentType
       });
@@ -135,7 +133,6 @@ export class FileController {
 
       const contentType = this._getContentTypeFromExtension(filename);
 
-      //return loadedFile
       response.header({
         'Content-type': contentType
       });

--- a/server/controllers/file.controller.ts
+++ b/server/controllers/file.controller.ts
@@ -60,7 +60,6 @@ export class FileController {
 
       const contentType = this._getContentTypeFromExtension(filename);
 
-      //return loadedFile
       response.header({
         'Content-type': contentType
       });
@@ -96,7 +95,6 @@ export class FileController {
       const loadedFile = fs.readFileSync(filename);
       const contentType = this._getContentTypeFromExtension(filename);
 
-      //return loadedFile
       response.header({
         'Content-type': contentType
       });
@@ -135,7 +133,6 @@ export class FileController {
 
       const contentType = this._getContentTypeFromExtension(filename);
 
-      //return loadedFile
       response.header({
         'Content-type': contentType
       });
@@ -160,7 +157,6 @@ export class FileController {
      */
     let contentType = 'image/jpeg';
     const extension = path.extname(fileName ?? '');
-    console.log(fileName, extension);
     switch (extension.toLowerCase()) {
       case '.jpg':
       case '.jpeg':

--- a/server/controllers/file.controller.ts
+++ b/server/controllers/file.controller.ts
@@ -1,14 +1,15 @@
-import { Persistence } from "../persistence";
-import { getFiles, mapFileInformations } from "../file.utilts";
-import { ENDPOINTS, FileInfo, SERVER_URL } from "@memebox/contracts";
-import fs from "fs";
-import { allowedFileUrl } from "../validations";
-import { Controller, Get, Inject, PathParams, Req } from "@tsed/common";
-import { PERSISTENCE_DI } from "../providers/contracts";
-import { NotFound, PreconditionFailed } from "@tsed/exceptions";
-import type { Request } from 'express';
-import { GetPreviewFilePath } from "../persistence.functions";
-import { safeResolve } from "../path.utils";
+import { Persistence } from '../persistence';
+import { getFiles, mapFileInformations } from '../file.utilts';
+import { ENDPOINTS, FileInfo, SERVER_URL } from '@memebox/contracts';
+import fs from 'fs';
+import { allowedFileUrl } from '../validations';
+import { Controller, Get, Inject, PathParams, Req, Res } from '@tsed/common';
+import { PERSISTENCE_DI } from '../providers/contracts';
+import { NotFound, PreconditionFailed } from '@tsed/exceptions';
+import type { Request, Response } from 'express';
+import { GetPreviewFilePath } from '../persistence.functions';
+import { safeResolve } from '../path.utils';
+import path from 'path';
 
 
 @Controller(ENDPOINTS.FILE.PREFIX)
@@ -34,9 +35,10 @@ export class FileController {
 
   @Get(`${ENDPOINTS.FILE.BY_ID}:mediaId`)
   getById(
-    @PathParams("mediaId") mediaId: string,
+    @PathParams('mediaId') mediaId: string,
+    @Res() response: Response
   ): Buffer {
-    if (!mediaId){
+    if (!mediaId) {
       throw new PreconditionFailed('need a media ID');
     }
 
@@ -56,18 +58,23 @@ export class FileController {
     if (fs.existsSync(filename)) {
       const loadedFile = fs.readFileSync(filename);
 
-      return loadedFile;
+      const contentType = this._getContentTypeFromExtension(filename);
+
+      //return loadedFile
+      response.header({
+        'Content-type': contentType
+      }).status(200).send(loadedFile);
     }
 
     throw new NotFound('no media file found');
   }
 
-
   @Get(`${ENDPOINTS.FILE.PREVIEW}:mediaId`)
   getPreviewById(
-    @PathParams("mediaId") mediaId: string,
+    @PathParams('mediaId') mediaId: string,
+    @Res() response: Response
   ): Buffer {
-    if (!mediaId){
+    if (!mediaId) {
       throw new PreconditionFailed('need a media ID');
     }
 
@@ -85,8 +92,12 @@ export class FileController {
 
     if (fs.existsSync(filename)) {
       const loadedFile = fs.readFileSync(filename);
+      const contentType = this._getContentTypeFromExtension(filename);
 
-      return loadedFile;
+      //return loadedFile
+      response.header({
+        'Content-type': contentType
+      }).status(200).send(loadedFile);
     }
 
     throw new NotFound('no media file found');
@@ -97,10 +108,11 @@ export class FileController {
   @Get(ENDPOINTS.FILE.ANY_FILE)
   getByPath(
     @Req() request: Request,
+    @Res() response: Response
   ): Buffer {
     const firstParam = request.params[0];
 
-    if (!firstParam){
+    if (!firstParam) {
       throw new PreconditionFailed('need a param');
     }
 
@@ -117,9 +129,45 @@ export class FileController {
     if (fs.existsSync(filename)) {
       const loadedFile = fs.readFileSync(filename);
 
-      return loadedFile;
+      const contentType = this._getContentTypeFromExtension(filename);
+
+      //return loadedFile
+      response.header({
+        'Content-type': contentType
+      }).status(200).send(loadedFile);
     }
 
     throw new NotFound('no media file found');
+  }
+
+  _getContentTypeFromExtension(fileName: string): string {
+    /*
+     * Image content types:
+     * image/gif
+     * image/jpeg
+     * image/png
+     * image/tiff
+     * image/vnd.microsoft.icon
+     * image/x-icon
+     * image/vnd.djvu
+     * image/svg+xml
+     */
+    let contentType = 'image/jpeg';
+    switch (path.extname(fileName?.toLowerCase() ?? '')) {
+      case 'jpg':
+      case 'jpeg':
+        contentType = 'image/jpeg';
+        break;
+
+      case 'png':
+        contentType = 'image/png';
+        break;
+
+      case 'gif':
+        contentType = 'image/gif';
+        break;
+    }
+
+    return contentType;
   }
 }


### PR DESCRIPTION
When the Action images/thumbnails are returned by the API they were missing a content type header making it harder to use the same links outside of MemeBox or even using the `Right click > open image in new tab` context menu option