### PR TITLE
Update installation documentation

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,57 @@
+# Building MemeBox from source
+
+The following is a step-by-step guide of how to build MemeBox completely from source. But first, a few tools are required to get started.
+
+## Prerequisites
+
+MemeBox is built almost exclusively with JavaScript/TypeScript. Therefore, Node.js and the Node Package Manager (`npm`) are needed. In addition, a version manager for Node.js is recommended. It allows you to install and use different versions of Node.js at the same time.
+
+Most of this software is likely easiest managed by some kind of software or package manager, like **Chocolatey**/**Scoop** on Windows, **Homebrew** on macOS and **apt**/**dnf**/**pacman**/... on Linux. If you prefer to install these manually, you're free to do so. Each project has either a dedicated website or GitHub project page, with installation instructions.
+
+- `git`: The version control system used to track changes of the project.
+- `node`: The Node.js runtime, used for building and running JavaScript based software.
+- `nvm`: A version manager for Node.js. There are others like `fnm` or `volta` as well, all with a very similar setup and usage style.
+
+## Clone the repository
+
+First, clone the repo into a local folder and use `npm` to install all required dependencies. Depending on what part of the application you want to build (standalone CLI tool, or Electron application), you might need to switch to a specific Node.js version first.
+
+```sh
+git clone https://github.com/negue/meme-box.git # or git@github.com:negue/meme-box
+cd meme-box
+```
+
+**NOTE:** If you don't want to install Git, or just want to build this as a one-off task, you can instead navigate the GitHub page and download the source as a `*.zip` or `*.tar.gz` archive and extract it locally.
+
+## Headless CLI binary
+
+If you want to build the _headless_ CLI variant, you currently have to use specifically Node.js **v12.16.2**. Otherwise, the latest version or LTS version should be sufficient. For example, using [nvm](https://github.com/nvm-sh/nvm):
+
+
+```sh
+# Only needed if you want to build the headless variant!
+nvm install 12.16.2
+```
+
+Then, build the binary with the following commands (for Windows in this example):
+
+```sh
+npm install --legacy-peer-deps
+npm run build:prepare
+npm run build:windows # or build:macos / build:linux
+```
+
+On macOS, use `npm build:macos`, on Linux, use `npm build:linux` instead, as the last build step.
+
+Afterwards, the standalone binary can be found in the `release/out/` folder.
+
+## Full application (Electron based)
+
+If you want to build the complete Electron application, which includes the user interface bundled as a regular application, execute the following commands:
+
+```sh
+npm install --legacy-peer-deps
+npm run electron:build
+```
+
+The built application can be found in the `release-electron/` folder, specific to your current operating system.

--- a/README.md
+++ b/README.md
@@ -24,45 +24,7 @@ A complete management app for [`image / audio / video / iframe / widgets`](/tuto
 
 ### From source
 
-First, clone the repo into a local folder and use `npm` to install all required dependencies. Depending on what part of the application you want to build (standalone CLI tool, or Electron application), you might need to switch to a specific Node.js version first.
-
-```sh
-git clone https://github.com/negue/meme-box.git # or git@github.com:negue/meme-box
-cd meme-box
-```
-
-#### Headless CLI binary
-
-If you want to build the _headless_ CLI variant, you currently have to use specifically Node.js **v12.16.2**. Otherwise, the latest version or LTS version should be sufficient. For example, using [nvm](https://github.com/nvm-sh/nvm):
-
-
-```sh
-# Only needed if you want to build the headless variant!
-nvm install 12.16.2
-```
-
-Then, build the binary with the following commands (for Windows in this example):
-
-```sh
-npm install --legacy-peer-deps
-npm run build:prepare
-npm run build:windows # or build:macos / build:linux
-```
-
-On macOS, use `npm build:macos`, on Linux, use `npm build:linux` instead, as the last build step.
-
-Afterwards, the standalone binary can be found in the `release/out/` folder.
-
-#### Full application (Electron based)
-
-If you want to build the complete Electron application, which includes the user interface bundled as a regular application, execute the following commands:
-
-```sh
-npm install --legacy-peer-deps
-npm run electron:build
-```
-
-The built application can be found in the `release-electron/` folder, specific to your current operating system.
+If you would like to build MemeBox from source, have a look at our dedicated [BUILD.md](BUILD.md).
 
 ### From AUR
 

--- a/README.md
+++ b/README.md
@@ -16,11 +16,21 @@ A complete management app for [`image / audio / video / iframe / widgets`](/tuto
 |--|--|
 |![memebox example setup gif](./assets/memebox_example_mobile_view.gif)|![memebox example twitch trigger gif](./assets/memebox_example_twitch.gif)|
 
+## Installation
 
-## Download
+### Pre-built binaries
 
 [Download latest release!](https://github.com/negue/meme-box/releases) (currently a bit ouf of date, new release soon) - [latest nightly Builds](https://github.com/negue/meme-box-nightly/releases)
 
+### From AUR
+
+If you're an Arch Linux user, you can install directly from the [AUR](https://aur.archlinux.org), using one of the [AUR helpers](https://wiki.archlinux.org/title/AUR_helpers).
+
+For example, with `paru`:
+
+```sh
+paru -S memebox
+```
 
 ## Working Features
 
@@ -174,10 +184,10 @@ See finished and upcoming changes in:
 * Find bugs
 * Suggestions to make `things` (UI, Text, Docs etc) more understandable
 * Help fix bugs / improve features
-  * [Good First Issues](https://github.com/negue/meme-box/labels/good%20first%20issue) 
+  * [Good First Issues](https://github.com/negue/meme-box/labels/good%20first%20issue)
   * [Open for Contribution](https://github.com/negue/meme-box/labels/open%20for%20contribution)
   * [Developers Sanity](https://github.com/negue/meme-box/labels/developers%20sanity)
-  * or all other Issue, in case I missed to label them: https://github.com/negue/meme-box/issues 
+  * or all other Issue, in case I missed to label them: https://github.com/negue/meme-box/issues
 * Star it :)
 
 [`Getting started with Development`](README_DEV.md)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,48 @@ A complete management app for [`image / audio / video / iframe / widgets`](/tuto
 
 [Download latest release!](https://github.com/negue/meme-box/releases) (currently a bit ouf of date, new release soon) - [latest nightly Builds](https://github.com/negue/meme-box-nightly/releases)
 
+### From source
+
+First, clone the repo into a local folder and use `npm` to install all required dependencies. Depending on what part of the application you want to build (standalone CLI tool, or Electron application), you might need to switch to a specific Node.js version first.
+
+```sh
+git clone https://github.com/negue/meme-box.git # or git@github.com:negue/meme-box
+cd meme-box
+```
+
+#### Headless CLI binary
+
+If you want to build the _headless_ CLI variant, you currently have to use specifically Node.js **v12.16.2**. Otherwise, the latest version or LTS version should be sufficient. For example, using [nvm](https://github.com/nvm-sh/nvm):
+
+
+```sh
+# Only needed if you want to build the headless variant!
+nvm install 12.16.2
+```
+
+Then, build the binary with the following commands (for Windows in this example):
+
+```sh
+npm install --legacy-peer-deps
+npm run build:prepare
+npm run build:windows # or build:macos / build:linux
+```
+
+On macOS, use `npm build:macos`, on Linux, use `npm build:linux` instead, as the last build step.
+
+Afterwards, the standalone binary can be found in the `release/out/` folder.
+
+#### Full application (Electron based)
+
+If you want to build the complete Electron application, which includes the user interface bundled as a regular application, execute the following commands:
+
+```sh
+npm install --legacy-peer-deps
+npm run electron:build
+```
+
+The built application can be found in the `release-electron/` folder, specific to your current operating system.
+
 ### From AUR
 
 If you're an Arch Linux user, you can install directly from the [AUR](https://aur.archlinux.org), using one of the [AUR helpers](https://wiki.archlinux.org/title/AUR_helpers).


### PR DESCRIPTION
I recently created a package for Arch Linux (AUR), that allows to easily build and install MemeBox on that specific Linux OS. Thought, it's worth mentioning that in the readme.

In addition, I added instructions on how to build the whole application (both headless and Electron variant) from source, for anybody who wants to build it themselves instead of using pre-compiled binaries.
