### PR TITLE
Use `pkg` for standalone binary bundling

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -46,10 +46,10 @@ jobs:
           path: |
             **/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/package.json') }}
-      - name: Use Node.js 12.16.2
+      - name: Use Node.js 16
         uses: actions/setup-node@v1
         with:
-          node-version: 12.16.2
+          node-version: 16
       - name: Declare some variables
         id: vars
         shell: bash
@@ -171,10 +171,10 @@ jobs:
           path: |
             **/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/package.json') }}
-      - name: Use Node.js 12.16.2
+      - name: Use Node.js 16
         uses: actions/setup-node@v1
         with:
-          node-version: 12.16.2
+          node-version: 16
 
       - run: npm install
 
@@ -221,10 +221,10 @@ jobs:
           path: |
             **/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/package.json') }}
-      - name: Use Node.js 12.16.2
+      - name: Use Node.js 16
         uses: actions/setup-node@v1
         with:
-          node-version: 12.16.2
+          node-version: 16
 
       - run: npm install
 

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -75,7 +75,7 @@ jobs:
           name: version_info
           path: './src/version_info.json'
 
-      - run: npm install
+      - run: npm install --legacy-peer-deps
       - run: npm run build:prepare
       - run: npm run build:all
 
@@ -176,7 +176,7 @@ jobs:
         with:
           node-version: 16
 
-      - run: npm install
+      - run: npm install --legacy-peer-deps
 
       - name: Download Angular Output from build
         uses: actions/download-artifact@v2
@@ -226,7 +226,7 @@ jobs:
         with:
           node-version: 16
 
-      - run: npm install
+      - run: npm install --legacy-peer-deps
 
       - name: Download Angular Output from build
         uses: actions/download-artifact@v2

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           node-version: 16
 
-      - run: npm install
+      - run: npm install --legacy-peer-deps
       - run: npm run build:prepare
       - run: npm run build:pkg -- -o release/out/memebox
 

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Run Cypress tests 🧪
         uses: cypress-io/github-action@v2
         with:
+          install-command: npm ci --legacy-peer-deps
           command: npm run test:cypress
 
   build_executables:

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -59,7 +59,7 @@ jobs:
 
       - run: npm install
       - run: npm run build:prepare
-      - run: npm run build:nexe -- -o release/out/memebox
+      - run: npm run build:pkg -- -o release/out/memebox
 
       - run: release/out/memebox --cli-test-mode=true  --config=./release/config
 

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -22,10 +22,10 @@ jobs:
           path: |
             **/node_modules
           key: ${{ runner.os }}-${{ hashFiles('package.json') }}
-      - name: Use Node.js 12.16.2
+      - name: Use Node.js 16
         uses: actions/setup-node@v1
         with:
-          node-version: 12.16.2
+          node-version: 16
       - run: npm install --legacy-peer-deps
       - name: Run Affected Lint
         shell: bash
@@ -52,10 +52,10 @@ jobs:
           path: |
             **/node_modules
           key: ${{ runner.os }}-${{ hashFiles('package.json') }}
-      - name: Use Node.js 12.16.2
+      - name: Use Node.js 16
         uses: actions/setup-node@v1
         with:
-          node-version: 12.16.2
+          node-version: 16
 
       - run: npm install
       - run: npm run build:prepare

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,9 @@
         "xss": "1.0.10",
         "zone.js": "0.10.3"
       },
+      "bin": {
+        "memebox": "release/memebox.js"
+      },
       "devDependencies": {
         "@angular-builders/custom-webpack": "11.0.0",
         "@angular-builders/jest": "11.1.1",

--- a/package.json
+++ b/package.json
@@ -36,10 +36,10 @@
     "build:prepare:folder": "cpy ncc/index.js release --rename=memebox.js && cpy node_modules/vm2/lib/{fixasync,sandbox,contextify}.js release",
     "build:prepare": "npm run build:prod && npm run build:prepare:withoutapp",
     "build:prepare:withoutapp": "npm run build:server && npm run build:prepare:folder",
-    "build:nexe": "npx nexe -i release/memebox.js -r dist -r release/{*.js,!memebox.js} --verbose",
-    "build:windows": "npm run build:nexe -- -t windows-x64 -o release/out/memebox.exe",
-    "build:linux": "npm run build:nexe -- -t linux-x64 -o release/out/memebox-linux",
-    "build:macos": "npm run build:nexe -- -t mac-x64 -o release/out/memebox-macos",
+    "build:pkg": "npx pkg .",
+    "build:windows": "npm run build:pkg -- -t win-x64 -o release/out/memebox.exe",
+    "build:linux": "npm run build:pkg -- -t linux-x64 -o release/out/memebox-linux",
+    "build:macos": "npm run build:pkg -- -t macos-x64 -o release/out/memebox-macos",
     "build:all": "npm run build:windows && npm run build:linux && npm run build:macos",
     "build:with-electron": "npm run electron:serve-tsc && npm run build",
     "electron:serve-tsc:watch": "ttsc -p tsconfig-electron.json -w -outDir out-electron",
@@ -203,5 +203,14 @@
   "browser": {
     "path": false,
     "fs": false
+  },
+  "bin": "release/memebox.js",
+  "pkg": {
+    "scripts": "release/*.js",
+    "assets": [
+      "release/*.js",
+      "dist/**/*"
+    ],
+    "outputPath": "release/pkg"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "keywords": [],
   "main": "out-electron/index.js",
+  "bin": "release/memebox.js",
   "private": true,
   "scripts": {
     "postinstall": "electron-builder install-app-deps && node ./decorate-angular-cli.js && ngcc --properties es2015 browser module main",
@@ -204,13 +205,11 @@
     "path": false,
     "fs": false
   },
-  "bin": "release/memebox.js",
   "pkg": {
-    "scripts": "release/*.js",
     "assets": [
-      "release/*.js",
-      "dist/**/*"
+      "dist/**/*",
+      "release/{*.js,!memebox.js}"
     ],
-    "outputPath": "release/pkg"
+    "outputPath": "release/out"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "build:prepare:folder": "cpy ncc/index.js release --rename=memebox.js && cpy node_modules/vm2/lib/{fixasync,sandbox,contextify}.js release",
     "build:prepare": "npm run build:prod && npm run build:prepare:withoutapp",
     "build:prepare:withoutapp": "npm run build:server && npm run build:prepare:folder",
-    "build:pkg": "npx pkg .",
+    "build:pkg": "npx pkg@5.8.0 .",
     "build:windows": "npm run build:pkg -- -t win-x64 -o release/out/memebox.exe",
     "build:linux": "npm run build:pkg -- -t linux-x64 -o release/out/memebox-linux",
     "build:macos": "npm run build:pkg -- -t macos-x64 -o release/out/memebox-macos",

--- a/server/file.utilts.ts
+++ b/server/file.utilts.ts
@@ -67,13 +67,13 @@ export function mapFileInformations (
 const versions = process.versions;
 export const isInElectron = !!versions['electron'];
 
-
 export function getAppRootPath () {
   const baseDir = dirname(process.execPath);
 
   const defaultAppOutPutDir = join(baseDir, '/dist');
+  const isBundled = isInElectron || !!versions['pkg'];
 
-  let appRootPath = isInElectron
+  let appRootPath = isBundled
     ? join(__dirname, '/../dist')
     : defaultAppOutPutDir;
 
@@ -83,7 +83,7 @@ export function getAppRootPath () {
     return appRootPath;
   }
 
-  if (!appRootPathExists && isInElectron) {
+  if (!appRootPathExists && isBundled) {
     const nodeModulesPos = baseDir.indexOf('node_modules');
 
     // serving electron without a built/copied app yet


### PR DESCRIPTION
My attempt to get `pkg` working as an alternative to `nexe`, so we're not bound to Node 12.16.2 anymore. So far seems to work, as far as I could tell, but I didn't test much of any specific features.

Probably there is some duplicate in the `package.json` by double-bundling `release/*.js` as scripts AND assets. Thought to look into that a bit further, but maybe best to verify that everything works and then we can tweak the settings.

You mentioned some special behavior with `nexe` and `vm2` for the scripting feature. Maybe you can give that a quick try with this PR or tell me how to test that myself?
