### PR TITLE
Create a more crisp tray icon

### DIFF
--- a/electron-shell.ts
+++ b/electron-shell.ts
@@ -54,14 +54,20 @@ function createTray () {
 
   const appRootPath = getAppRootPath();
 
-  const trayIcon = join(appRootPath, 'assets/icons/favicon.256x256.png');
-  const trayIconNativeImage = nativeImage.createFromPath(
-    trayIcon
-  );
+  const trayIconPath = join(appRootPath, 'assets/icons/icon-128x128.png');
+  const trayIcon = nativeImage.createFromPath(trayIconPath);
+  const trayIconScaled = nativeImage.createEmpty();
 
-  const resized = trayIconNativeImage.resize({ width: 16, height: 16 });
+  for (let i = 1; i <= 3; i++) {
+    trayIconScaled.addRepresentation({
+      scaleFactor: i,
+      width: 32 * i,
+      height: 32 * i,
+      buffer: trayIcon.resize({ width: 32 * i, height: 32 * i }).toBitmap(),
+    });
+  }
 
-  tray = new Tray(resized);
+  tray = new Tray(trayIconScaled);
 
   let template = [{
     label: 'Toggle',


### PR DESCRIPTION
This changes the tray icon generation, to have a more crisp variant, and apply scaling variations for HiDPI factors. It is very similar to the appreach mention in the docs where you'd have multiple icons like `32x32.png`, `32x32@2.png` and `32x32@3.png` where the `@2` and `@3` variant are for double and triple DPI values.

- Using the 128x128 icon variant to likely create more crisp scaled versions, as less resizing is needed (may make the initialization faster too, as it's faster to rescale, because less pixels to process).
- Create scaled versions for different DPI scaling factors, namely 32x32, 64x64 and 128x128.

This looks good on Linux so far. Seems macOS doesn't really care about the custom tray icon and builds the silouhette variant itself from the main app icon (at least it appears to do that, because the silouhette version looked crip, even before this change).

@negue could you check how this looks on Windows? I assume the original 16x16 was picked, because that's a typical basic size for ICO files on Windows. Just good to check that it doesn't fail to show the icon on Windows, and still looks crips there too. Sadly don't have a Windows PC around to check this myself.

Fixes #519