### PR TITLE
Feature: Recipe Random Command Group

### DIFF
--- a/projects/recipe-core/src/lib/command-blocks.generic.ts
+++ b/projects/recipe-core/src/lib/command-blocks.generic.ts
@@ -1,0 +1,111 @@
+import {generateCodeByStep, RecipeCommandBlockRegistry} from "./recipe.types";
+import {generateRandomCharacters} from "./utils";
+
+export function registerGenericCommandBlocks(
+  registry: RecipeCommandBlockRegistry,
+  generateCodeByStep: generateCodeByStep
+): void {
+  registry["sleepSeconds"] = {
+    pickerLabel: "Wait for Seconds",
+    commandGroup: "generic",
+    configArguments: [
+      {
+        name: "seconds",
+        label: "Seconds",
+        type: "number"
+      }
+    ],
+    toScriptCode: (step, context) => `sleep.secondsAsync(${step.payload.seconds});`,
+    commandEntryLabelAsync: (queries, payload, parentStep) => {
+      return Promise.resolve(`sleep: ${payload.seconds} seconds`);
+    },
+    entryIcon: () => 'hourglass_top'
+  };
+
+
+  registry["sleepMs"] = {
+    pickerLabel: "Wait for Milliseconds",
+    commandGroup: "generic",
+    configArguments: [
+      {
+        name: "ms",
+        label: "Milliseconds",
+        type: "number"
+      }
+    ],
+    toScriptCode: (step, context) => `sleep.msAsync(${step.payload.ms});`,
+    commandEntryLabelAsync: (queries, payload, parentStep) => {
+      return Promise.resolve(`sleep: ${payload.ms}ms`);
+    },
+    entryIcon: () => 'hourglass_top'
+  };
+
+  registry["randomCommandGroup"] = {
+    pickerLabel: "Random Command Group",
+    commandGroup: "generic",
+    configArguments: [
+      {
+        name: 'amountOfGroups',
+        label: 'Amount of Groups',
+        type: "number"
+      }
+    ],
+    extendCommandBlockOnEdit: true,
+    extendCommandBlock: (step) => {
+      const amountOfGroups = step.payload.amountOfGroups as number;
+
+      if (step.subCommandBlocks.length === amountOfGroups) {
+        return;
+      }
+
+      if (amountOfGroups < step.subCommandBlocks.length) {
+        step.subCommandBlocks.length = amountOfGroups;
+        return;
+      }
+
+
+      const newSubCommandBlockArray = [...step.subCommandBlocks];
+
+      for (let i = step.subCommandBlocks.length; i < amountOfGroups; i++) {
+        newSubCommandBlockArray.push({
+          labelId: generateRandomCharacters(5),
+          entries: []
+        });
+      }
+
+      step.subCommandBlocks = newSubCommandBlockArray
+    },
+    subCommandBlockLabelAsync: (queries, commandBlock, labelId) => {
+      return Promise.resolve('');
+    },
+    awaitCodeHandledInternally: true,
+    toScriptCode: (step, context, userData) => {
+      const awaitCode = step.awaited ? 'await ' : '';
+
+      const functionNames: string[] = [];
+
+      const generatedFunctions = generateCodeByStep(step, context, userData).map(g => {
+
+        const functionName = `randomGroup_${g.subCommand.labelId}`;
+
+        functionNames.push(functionName);
+
+        return `async function ${functionName}() {
+                 ${g.generatedScript}
+                }`;
+      }).join('\r\n');
+
+      return `
+        ${awaitCode} (() => {
+          ${generatedFunctions}
+
+        const functionsToChoose = [${functionNames.join(',')}];
+
+        return utils.randomElement(functionsToChoose)();
+        })();`;
+    },
+    commandEntryLabelAsync: (queries, payload, parentStep) => {
+      return 'trigger any of these command groups randomly';
+    }
+  };
+}

--- a/projects/recipe-core/src/lib/command-blocks.memebox.ts
+++ b/projects/recipe-core/src/lib/command-blocks.memebox.ts
@@ -135,7 +135,7 @@ export function registerMemeboxCommandBlocks(
 
       return `${createMemeboxApiVariable(actionPayload)}
                      .triggerWhile(async (helpers_${step.payload._suffix}) => {
-                        ${generateCodeByStep(step, context, userData)}
+                        ${generateCodeByStep(step, context, userData)[0].generatedScript}
                       }
                       ${actionOverrides ? ',' + JSON.stringify(actionOverrides) : ''});`;
     },

--- a/projects/recipe-core/src/lib/recipe.types.ts
+++ b/projects/recipe-core/src/lib/recipe.types.ts
@@ -18,13 +18,15 @@ export interface RecipeCommandInfo {
 
 // at some point custom controls/ui for each stepInfo could be shown
 
+export interface RecipeSubCommandBlock {
+  labelId: string;
+  entries: string[]  // entryId
+}
+
 export interface RecipeEntryBase {
   id: string;
   awaited?: boolean;
-  subCommandBlocks: {
-    labelId: string;
-    entries: string[]  // entryId
-  }[];
+  subCommandBlocks: RecipeSubCommandBlock[];
 }
 
 export interface RecipeEntryCommandPayload {
@@ -112,6 +114,7 @@ export interface RecipeCommandDefinition {
   allowedToBeAdded?: (step: RecipeEntry, context: RecipeContext) => boolean;
   toScriptCode: (step: RecipeEntryCommandCall, context: RecipeContext, userData: UserDataState) => string;
   awaitCodeHandledInternally?: boolean;
+  extendCommandBlockOnEdit?: boolean;
   commandType?: string;
 }
 
@@ -123,5 +126,8 @@ export interface RecipeCommandSelectionGroup {
 export interface RecipeCommandBlockRegistry {
   [stepType: string]: RecipeCommandDefinition
 }
-
-export type generateCodeByStep = (step: RecipeEntry, context: RecipeContext, userData: UserDataState) => string;
+export interface generatedCodeBySubCommandBlock {
+  subCommand: RecipeSubCommandBlock;
+  generatedScript: string;
+}
+export type generateCodeByStep = (step: RecipeEntry, context: RecipeContext, userData: UserDataState) => generatedCodeBySubCommandBlock[];

--- a/projects/recipe-core/src/lib/recipeCommandRegistry.ts
+++ b/projects/recipe-core/src/lib/recipeCommandRegistry.ts
@@ -1,36 +1,5 @@
 import {RecipeCommandBlockRegistry} from "./recipe.types";
 
 export const RecipeCommandRegistry: RecipeCommandBlockRegistry = {
-  "sleepSeconds": {
-    pickerLabel: "Wait for Seconds",
-    commandGroup: "generic",
-    configArguments: [
-      {
-        name: "seconds",
-        label: "Seconds",
-        type: "number"
-      }
-    ],
-    toScriptCode: (step, context) => `sleep.secondsAsync(${step.payload.seconds});`,
-    commandEntryLabelAsync: (queries, payload, parentStep) => {
-      return Promise.resolve(`sleep: ${payload.seconds} seconds`);
-    },
-    entryIcon: () => 'hourglass_top'
-  },
-  "sleepMs": {
-    pickerLabel: "Wait for Milliseconds",
-    commandGroup: "generic",
-    configArguments: [
-      {
-        name: "ms",
-        label: "Milliseconds",
-        type: "number"
-      }
-    ],
-    toScriptCode: (step, context) => `sleep.msAsync(${step.payload.ms});`,
-    commandEntryLabelAsync: (queries, payload, parentStep) => {
-      return Promise.resolve(`sleep: ${payload.ms}ms`);
-    },
-    entryIcon: () => 'hourglass_top'
-  }
+
 };

--- a/projects/recipe-ui/src/lib/recipe-block/recipe-block.component.html
+++ b/projects/recipe-ui/src/lib/recipe-block/recipe-block.component.html
@@ -38,7 +38,6 @@
 
 </ng-container>
 
-
 <div cdkDropList class="entry-list"
      *ngFor="let subStepInfo of entry | getEntrySubBlockInfoArray$ | async"
      (cdkDropListDropped)="stepRearranged($event, subStepInfo)">

--- a/projects/recipe-ui/src/lib/recipe-block/recipe-block.component.ts
+++ b/projects/recipe-ui/src/lib/recipe-block/recipe-block.component.ts
@@ -1,5 +1,5 @@
 import {ChangeDetectorRef, Component, HostBinding, Input, OnDestroy, OnInit} from '@angular/core';
-import {RecipeEntry, RecipeEntryCommandCall, RecipeSubCommandInfo} from "@memebox/recipe-core";
+import {RecipeCommandRegistry, RecipeEntry, RecipeEntryCommandCall, RecipeSubCommandInfo} from "@memebox/recipe-core";
 import {CdkDragDrop} from "@angular/cdk/drag-drop";
 import {RecipeContextDirective} from "../recipe-context.directive";
 import {DialogService} from "../../../../../src/app/shared/dialogs/dialog.service";
@@ -105,7 +105,22 @@ export class RecipeBlockComponent
     const newPayload = await this.stepCreator.editStepData(entry, this.context.recipe!);
 
     if (newPayload) {
-      this.context.changePayload(entry, newPayload);
+      if (RecipeCommandRegistry[entry.commandBlockType].extendCommandBlockOnEdit) {
+        const newEntry = {
+          ...entry,
+          payload:newPayload,
+          subCommandBlocks: [...entry.subCommandBlocks]
+        };
+
+        RecipeCommandRegistry[entry.commandBlockType]?.extendCommandBlock?.(newEntry, parent)
+
+        this.context.changeEntry(newEntry);
+      }
+      else {
+
+        this.context.changePayload(entry, newPayload);
+      }
+
     }
   }
 }

--- a/projects/recipe-ui/src/lib/recipe-context.directive.ts
+++ b/projects/recipe-ui/src/lib/recipe-context.directive.ts
@@ -164,4 +164,10 @@ export class RecipeContextDirective
       }
     });
   }
+
+  changeEntry(entry: RecipeEntryCommandCall): void{
+    this.update(state => {
+      state.entries[entry.id] = entry;
+    })
+}
 }


### PR DESCRIPTION
New Command Block: Trigger a random Group 

![image](https://user-images.githubusercontent.com/842273/198378133-50c9eb9e-d55e-4fd6-aeb4-f557d7988476.png)
![image](https://user-images.githubusercontent.com/842273/198378413-33ec6ed7-4440-4be2-8049-06a6aa061118.png)

This creates a Command Block, which can have multiple sub groups inside, and only one of them will be triggered in random.
![image](https://user-images.githubusercontent.com/842273/198378625-3c51362a-3aa7-45d8-8c1d-5ae6594c2976.png)

All command blocks inside this group are handled as usual (so either awaited or not, depending on your setting).
