### PR TITLE
Set `legacy-peer-deps` in .npmrc

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -75,7 +75,7 @@ jobs:
           name: version_info
           path: './src/version_info.json'
 
-      - run: npm install --legacy-peer-deps
+      - run: npm install
       - run: npm run build:prepare
       - run: npm run build:all
 
@@ -176,7 +176,7 @@ jobs:
         with:
           node-version: 16
 
-      - run: npm install --legacy-peer-deps
+      - run: npm install
 
       - name: Download Angular Output from build
         uses: actions/download-artifact@v2
@@ -226,7 +226,7 @@ jobs:
         with:
           node-version: 16
 
-      - run: npm install --legacy-peer-deps
+      - run: npm install
 
       - name: Download Angular Output from build
         uses: actions/download-artifact@v2

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 16
-      - run: npm install --legacy-peer-deps
+      - run: npm install
         if: steps.cache-package.outputs.cache-hit != 'true'
       - name: Run Affected Lint
         shell: bash
@@ -61,7 +61,7 @@ jobs:
         with:
           node-version: 16
 
-      - run: npm install --legacy-peer-deps
+      - run: npm install
         if: steps.cache-package.outputs.cache-hit != 'true'
       - run: npm run build:prepare
       - run: npm run build:pkg -- -o release/out/memebox

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
+legacy-peer-deps=true
 save=true
 save-exact=true

--- a/BUILD.md
+++ b/BUILD.md
@@ -28,7 +28,7 @@ cd meme-box
 If you want to build the _headless_ CLI variant use the following commands (for Windows in this example):
 
 ```sh
-npm install --legacy-peer-deps
+npm install
 npm run build:prepare
 npm run build:windows # or build:macos / build:linux
 ```
@@ -42,7 +42,7 @@ Afterwards, the standalone binary can be found in the `release/out/` folder.
 If you want to build the complete Electron application, which includes the user interface bundled as a regular application, execute the following commands:
 
 ```sh
-npm install --legacy-peer-deps
+npm install
 npm run electron:build
 ```
 


### PR DESCRIPTION
Small convenience setting, that automatically enables `legacy-peer-deps`.

This is especially helpful with newer npm versions, as it even fails on a simple `npm install` without that extra argument. That is due to some behaviour changes in npm's peer dependency handling. Adding this avoids the mistake of forgetting to pass the extra `legacy-peer-deps` argument.
